### PR TITLE
Updated microservice-traffic chart

### DIFF
--- a/app/charts/microservice-traffic.tsx
+++ b/app/charts/microservice-traffic.tsx
@@ -2,10 +2,11 @@ import React, { useContext } from 'react';
 import Plot from 'react-plotly.js';
 import { CommsContext } from '../context/CommsContext';
 
-const MicroServiceTraffic = () => {
+const MicroServiceTraffic = () => { 
   const { commsData } = useContext(CommsContext);
-
+  console.log('hello from microservice traffice-->',commsData )
   const microServiceCountdictionary: { [key: string]: number } = {};
+  
   // iterate over Trace Points
   for (let i = 0; i < commsData.length; i += 1) {
     // populate Micro-count dictionary
@@ -14,6 +15,11 @@ const MicroServiceTraffic = () => {
     } else {
       microServiceCountdictionary[commsData[i].microservice] += 1;
     }
+  }
+  // iterating through the microServiceCountdictionary object and setting each microservice name into Xaxis array to spread into the graph
+  const xAxis = []
+  for (const keys in microServiceCountdictionary){
+    xAxis.push(keys)
   }
   // capture values of microServiceCountdictionary to use as data to populate chart object
   const serverPingCount: number[] = Object.values(microServiceCountdictionary);
@@ -79,7 +85,7 @@ const MicroServiceTraffic = () => {
       data={[
         {
           type: 'bar',
-          x: ['Orders', 'Customers', 'Books', 'Reverse-Proxy'],
+          x: [...xAxis],
           y: [...serverPingCount, 0, yAxisHeadRoom],
           fill: 'tozeroy',
           marker: { color: '#5C80FF' },

--- a/app/context/DockerContext.tsx
+++ b/app/context/DockerContext.tsx
@@ -57,6 +57,7 @@ const DockerContextProvider: React.FC = ({ children }) => {
 
       // Update context local state
       // setDockerData(freq);
+      
       const newDockerData = result[0] || {};
       setDockerData(newDockerData);
     });

--- a/app/context/HealthContext.tsx
+++ b/app/context/HealthContext.tsx
@@ -43,8 +43,9 @@ const HealthContextProvider: React.FC = ({ children }) => {
       // Update context local state
       setHealthData(freq);
     });
+    
   };
-
+  
   return (
     <HealthContext.Provider value={{ healthData, setHealthData, fetchHealthData }}>
       {children}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'index_bundle.js',
   },
-  devtool: 'source-map',
+  devtool: 'eval-source-map',
   module: {
     rules: [
       {


### PR DESCRIPTION
Updated the x-axis for the graph to reflect the total microservices being examined in the database. 

Removed the x axis hard coding and replaced it with an array of microservices that is spread out on the x axis. 

**on ToddDB:**
![Screenshot from 2020-07-01 19-31-22](https://user-images.githubusercontent.com/35882473/86309850-84df3100-bbd1-11ea-8368-46edb3e54620.png)

**on chronos-mon:**
![Screenshot from 2020-07-01 19-32-21](https://user-images.githubusercontent.com/35882473/86309885-99232e00-bbd1-11ea-8539-d35f9927b712.png)
