### PR TITLE
Upon build, automatically copy settings.json into build folder

### DIFF
--- a/utilities/copyDist.js
+++ b/utilities/copyDist.js
@@ -55,3 +55,9 @@ fse.copyFileSync(
   path.resolve(__dirname, '../settings.json'),
   path.resolve(__dirname, '../dist/settings.json')
 );
+
+// Copy settings.json from root directory into the build folder
+fse.copyFileSync(
+  path.resolve(__dirname, '../settings.json'),
+  path.resolve(__dirname, '../build/settings.json')
+);


### PR DESCRIPTION

# Types of changes
- [ ]  Automated addition of settings.json (our current credentials) into the build folder
- [ ] We no longer have to manually move or duplicate and add the settings.json file into the build folder.
