### PR TITLE
Fixed user signup and pw validation bug

### DIFF
--- a/app/components/SignUp.tsx
+++ b/app/components/SignUp.tsx
@@ -22,6 +22,10 @@ const SignUp:React.FC = React.memo(() => {
     // eslint-disable-next-line no-return-assign
     inputFields.forEach(input => (input.value = ''));
 
+    if (!password) {
+      setFailedSignUp(<p>Please enter valid password</p>)
+      return;
+    }
     if (password !== confirmPassword) {
       setFailedSignUp(<p>Entered passwords do not match</p>);
       return;


### PR DESCRIPTION
Co-authored-by: Jon Cruz
Jrcrz@users.noreply.github.com
Co-authored-by: Elena Atencio
elenaatencio@users.noreply.github.com
Co-authored-by: John Donato
jdonuto@users.noreply.github.com

References issue #. Please review this @teammember1, @teammember2.

# Types of changes
- [x ]  Bugfix (change which fixes an issue)
- [ ]  New feature (change which adds functionality)
- [x ]  Refactor (change which changes the codebase without affecting its external behavior)
- [x ]  Non-breaking change (fix or feature that would cause existing functionality to work as expected)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
# Purpose
- Enable user sign up functionality
- Fix minor bugs causing lack of interaction between frontend and backend
# Approach
Previously when tried to sign up, error shows: 
(Failed to sign up: Error: Error invoking remote method 'addUser': No handler registered for 'addUser')
- Changed ipcMain.on() to ipcMain.handle() to address error (inside dashboard.ts)
- Previous code fails to check if username already exists in file – changed code from (‘username in settings’ to ‘settings[username]’) 
- Valid signup credentials are passed in and readFileSync was invoked in the backend to check if the same username exists inside file but ipcRenderer.invoke() is not set up to check for any return value from ipcMain.handle(). Instead, it always defaulted to setFailedSignUp(). Nothing is sent back to frontend(SignUp.tsx) to allow for new user to navigate to main page. 
- Fixed up if/else statements and changed code to return ‘message.returnValue’ from ipcMain.handle(). Frontend now checks for this ‘message’ (boolean) to navigate user to home page or to return message from failedSignUp

